### PR TITLE
Remove years range from the footer

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -272,7 +272,7 @@
 
 <footer class="footer">
     <div class="footer__copyright">
-        &copy;&nbsp;1984–2021 Artem&nbsp;Koziar
+        &copy;&nbsp;2021 Artem&nbsp;Koziar
     </div>
     <div class="hitua">
         <a href="https://tx10.io/" target="_blank" style="color:#eee; text-decoration: none;">Tx10 💛💙</a>


### PR DESCRIPTION
The specified range 1984-2021 near your name looks really scary and motivates to urgent check who posts on the your facebook page instead of you :)